### PR TITLE
Error handling in writing to the .evn file

### DIFF
--- a/app/Http/Controllers/Admin/InstallController.php
+++ b/app/Http/Controllers/Admin/InstallController.php
@@ -68,10 +68,16 @@ class InstallController extends Controller
       $data = $request->all();
       $env = new Env();
       foreach ($data as $key => $value) {
-          if( $key == "VAOS_ORG_NAME" || $key == "VAOS_ORG_EMAIL" ) {
+          if( $key == "VAOS_ORG_NAME" || $key == "VAOS_ORG_EMAIL") {
+            if ($value[0] == '"') {
               $env->changeEnv([
-                  $key => '"'. $value .'"'
+                $key => $value
               ]);
+            }else{
+              $env->changeEnv([
+                $key => '"' . $value . '"'
+              ]);
+            }
           }else{
               $env->changeEnv([
                   $key => $value


### PR DESCRIPTION
If the quotes stay in the form an other quote was added and the system crashed. Now this error is handled