### PR TITLE
Change the functionality how aircraft group are added to Schedule

### DIFF
--- a/app/Classes/VAOS_Aircraft.php
+++ b/app/Classes/VAOS_Aircraft.php
@@ -50,7 +50,7 @@ class VAOS_Aircraft
                 $acf->location()->associate($hub);
             }
             if (array_key_exists('airline', $data)) {
-                $air = Airline::find($data['airline']);
+                $air = Airline::where('icao', $data['airline'])->first();
 
                 $acf->airline()->associate($air);
             }
@@ -121,7 +121,7 @@ class VAOS_Aircraft
                 $acf->location()->associate($hub);
             }
             if (array_key_exists('airline', $data)) {
-                $air = Airline::find($data['airline']);
+                $air = Airline::where('icao', $data['airline'])->first();
 
                 $acf->airline()->associate($air);
             }

--- a/app/Classes/VAOS_Schedule.php
+++ b/app/Classes/VAOS_Schedule.php
@@ -135,7 +135,7 @@ class VAOS_Schedule
         $arr = Airport::where('icao', $data['arricao'])->first();
         $entry->depapt()->associate($dep);
         $entry->arrapt()->associate($arr);
-        $airline = Airline::find($data['airline']);
+        $airline = Airline::where('icao', $data['airline'])->first();
         $entry->airline()->associate($airline);
 
         if (array_key_exists('alticao', $data))
@@ -192,7 +192,7 @@ class VAOS_Schedule
         $arr = Airport::where('icao', $data['arricao'])->first();
         $entry->depapt()->associate($dep);
         $entry->arrapt()->associate($arr);
-        $airline = Airline::find($data['airline']);
+        $airline = Airline::where('icao', $data['airline'])->first();
         $entry->airline()->associate($airline);
 
         if (array_key_exists('alticao', $data))

--- a/app/Classes/VAOS_Schedule.php
+++ b/app/Classes/VAOS_Schedule.php
@@ -150,7 +150,7 @@ class VAOS_Schedule
         if (array_key_exists('aircraft_group', $data))
         {
             //dd($data);
-            $acfgrp = AircraftGroup::find($data['aircraft_group']);
+            $acfgrp = $acfgrp = AircraftGroup::where('icao', ($data['aircraft_group']))->first();
             $entry->aircraft_group()->associate($acfgrp);
         }
         $entry->seasonal = true;
@@ -207,7 +207,7 @@ class VAOS_Schedule
         if (array_key_exists('aircraft_group', $data))
         {
             //dd($data);
-            $acfgrp = AircraftGroup::find($data['aircraft_group']);
+            $acfgrp = $acfgrp = AircraftGroup::where('icao', ($data['aircraft_group']))->first();
             $entry->aircraft_group()->associate($acfgrp);
         }
         $entry->seasonal = true;

--- a/app/Classes/VAOS_Schedule.php
+++ b/app/Classes/VAOS_Schedule.php
@@ -150,7 +150,7 @@ class VAOS_Schedule
         if (array_key_exists('aircraft_group', $data))
         {
             //dd($data);
-            $acfgrp = $acfgrp = AircraftGroup::where('icao', ($data['aircraft_group']))->first();
+            $acfgrp = AircraftGroup::where('icao', ($data['aircraft_group']))->first();
             $entry->aircraft_group()->associate($acfgrp);
         }
         $entry->seasonal = true;

--- a/app/Http/Controllers/API/FleetAPI.php
+++ b/app/Http/Controllers/API/FleetAPI.php
@@ -98,7 +98,7 @@ class FleetAPI extends Controller
             $acf->location()->associate($hub);
         }
         if ($data['airline'] != null) {
-            $air = Airline::find($data['airline']);
+            $air = Airline::where('icao', $data['airline'])->first();
 
             $acf->airline()->associate($air);
         }

--- a/app/Http/Controllers/API/ScheduleAPI.php
+++ b/app/Http/Controllers/API/ScheduleAPI.php
@@ -101,7 +101,7 @@ class ScheduleAPI extends Controller
     	}
     	if ($request->has('aircraft_group'))
     	{
-    	    $acfgrp = AircraftGroup::find($request->input('aircraft_group'));
+    	    $acfgrp = AircraftGroup::where('icao', $request->input('aircraft_group'))->first();
     		$entry->aircraft_group()->associate($acfgrp);
     	}
     	$entry->seasonal = true;

--- a/composer.lock
+++ b/composer.lock
@@ -1388,16 +1388,16 @@
         },
         {
             "name": "maatwebsite/excel",
-            "version": "2.1.15",
+            "version": "2.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Maatwebsite/Laravel-Excel.git",
-                "reference": "dc8175357127ecd04c0511e6568cc8fc0e35c902"
+                "reference": "655def96b5e98d1fe0974d9c4e2ec5f2b591a322"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Maatwebsite/Laravel-Excel/zipball/dc8175357127ecd04c0511e6568cc8fc0e35c902",
-                "reference": "dc8175357127ecd04c0511e6568cc8fc0e35c902",
+                "url": "https://api.github.com/repos/Maatwebsite/Laravel-Excel/zipball/655def96b5e98d1fe0974d9c4e2ec5f2b591a322",
+                "reference": "655def96b5e98d1fe0974d9c4e2ec5f2b591a322",
                 "shasum": ""
             },
             "require": {
@@ -1452,7 +1452,7 @@
                 "import",
                 "laravel"
             ],
-            "time": "2017-03-28T02:19:13+00:00"
+            "time": "2017-03-28T10:47:04+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/resources/views/admin/fleet/create.blade.php
+++ b/resources/views/admin/fleet/create.blade.php
@@ -25,7 +25,7 @@
                                     <option value="0">No Airlines Found</option>
                                 @else
                                     @foreach($airlines as $a)
-                                    <option value="{{ $a->id }}">{{ $a->icao }} - {{ $a->name }}</option>
+                                    <option value="{{ $a->icao }}">{{ $a->icao }} - {{ $a->name }}</option>
                                     @endforeach
                                 @endif
                             </select>

--- a/resources/views/admin/fleet/edit.blade.php
+++ b/resources/views/admin/fleet/edit.blade.php
@@ -26,7 +26,7 @@
                                     <option value="0">No Airlines Found</option>
                                 @else
                                     @foreach($airlines as $a)
-                                    <option value="{{ $a->id }}" @if($a->id == $aircraft->airline->id) selected="selected" @endif>{{ $a->icao }} - {{ $a->name }}</option>
+                                    <option value="{{ $a->icao }}" @if($a->id == $aircraft->airline->id) selected="selected" @endif>{{ $a->icao }} - {{ $a->name }}</option>
                                     @endforeach
                                 @endif
                             </select>

--- a/resources/views/admin/partials/import_format/fleet.blade.php
+++ b/resources/views/admin/partials/import_format/fleet.blade.php
@@ -11,7 +11,7 @@
 		<td>status</td>
 	</tr>
 	<tr>
-		<td>1</td>
+		<td>JCO</td>
 		<td>B738</td>
 		<td>B737-800</td>
 		<td>Boeing</td>
@@ -22,7 +22,7 @@
 		<td>1</td>
 	</tr>
 	<tr>
-		<td>1</td>
+		<td>JCO</td>
 		<td>A320</td>
 		<td>A320-200</td>
 		<td>Airbus</td>

--- a/resources/views/admin/partials/import_format/schedule.blade.php
+++ b/resources/views/admin/partials/import_format/schedule.blade.php
@@ -14,7 +14,7 @@
 		<td>enabled</td>
 	</tr>
 	<tr>
-		<td>1</td>
+		<td>JCO</td>
 		<td>66</td>
 		<td>KABQ</td>
 		<td>KJFK</td>
@@ -28,7 +28,7 @@
 		<td>1</td>
 	</tr>
 	<tr>
-		<td>1</td>
+		<td>JCO</td>
 		<td>1492</td>
 		<td>KACK</td>
 		<td>KJFK</td>

--- a/resources/views/admin/schedules/create.blade.php
+++ b/resources/views/admin/schedules/create.blade.php
@@ -68,7 +68,7 @@
                         <div class="col-md-9">
                             <select id="aircraft_group" name="aircraft_group" class="form-control" size="1">
                                 @foreach($acfgroups as $acf)
-                                    <option value="{{ $acf->id }}">{{ $acf->name }}</option>
+                                    <option value="{{ $acf->icao }}">{{ $acf->name }}</option>
                                 @endforeach
                             </select>
                         </div>

--- a/resources/views/admin/schedules/create.blade.php
+++ b/resources/views/admin/schedules/create.blade.php
@@ -21,7 +21,7 @@
                         <div class="col-md-9">
                             <select id="airline" name="airline" class="form-control" size="1">
                                 @foreach($airlines as $a)
-                                    <option value="{{ $a->id }}">{{ $a->icao }} - {{ $a->name }}</option>
+                                    <option value="{{ $a->icao }}">{{ $a->icao }} - {{ $a->name }}</option>
                                 @endforeach
                             </select>
                         </div>

--- a/resources/views/admin/schedules/edit.blade.php
+++ b/resources/views/admin/schedules/edit.blade.php
@@ -23,7 +23,7 @@
                         <div class="col-md-9">
                             <select id="airline" name="airline" class="form-control" size="1">
                                 @foreach($airlines as $a)
-                                    <option value="{{ $a->id }}" @if($a->id == $schedule->airline->id) selected="selected" @endif>{{ $a->icao }} - {{ $a->name }}</option>
+                                    <option value="{{ $a->icao }}" @if($a->id == $schedule->airline->id) selected="selected" @endif>{{ $a->icao }} - {{ $a->name }}</option>
                                 @endforeach
                             </select>
                         </div>

--- a/resources/views/admin/schedules/edit.blade.php
+++ b/resources/views/admin/schedules/edit.blade.php
@@ -71,7 +71,7 @@
                             <select id="aircraft_group" name="aircraft_group" class="form-control" size="1">
                                 <option value="">Not Assigned</option>
                                 @foreach($acfgroups as $acf)
-                                    <option value="{{ $acf->id }}" @if(!empty($schedule->aircraft_group->id)) @if($acf->id == $schedule->aircraft_group->id) selected="selected" @endif @endif>{{ $acf->name }}</option>
+                                    <option value="{{ $acf->icao }}" @if(!empty($schedule->aircraft_group->id)) @if($acf->id == $schedule->aircraft_group->id) selected="selected" @endif @endif>{{ $acf->name }}</option>
                                 @endforeach
                             </select>
                         </div>


### PR DESCRIPTION
Aircraft Groups are now added to schedule by the icao code and not as before by ID. Now the import works like charm.

Update:
Airlines are now added to schedule and fleet by the icao code and not as before by ID.